### PR TITLE
build: build connector image for multiple platforms

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:16
+FROM --platform=$TARGETPLATFORM node:16
 WORKDIR /home/node/airbyte
 RUN npm install --location=global npm@7 tsc
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,4 @@
 FROM node:16
-RUN apt-get update
-RUN apt-get install qemu qemu-user-static binfmt-support debootstrap -y
 WORKDIR /home/node/airbyte
 RUN npm install --location=global npm@7 tsc
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:16
+FROM --platform=$BUILDPLATFORM node:16-alpine as builder
 WORKDIR /home/node/airbyte
 RUN npm install --location=global npm@7 tsc
 
@@ -9,5 +9,9 @@ COPY ./resources ./resources
 COPY ./src ./src
 COPY ./bin ./bin
 RUN npm run build
+
+FROM node:16-alpine
+WORKDIR /home/node/airbyte
+COPY --from=builder /home/node/airbyte /home/node/airbyte
 ENV AIRBYTE_ENTRYPOINT "/home/node/airbyte/bin/main"
 ENTRYPOINT ["/home/node/airbyte/bin/main"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,6 @@
 FROM --platform=$TARGETPLATFORM node:16
+RUN apt-get update
+RUN apt-get install qemu qemu-user-static binfmt-support debootstrap -y
 WORKDIR /home/node/airbyte
 RUN npm install --location=global npm@7 tsc
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM node:16-alpine
 
 WORKDIR /home/node/airbyte
-RUN npm install -g npm@7 tsc
+RUN npm install --location=global npm@7 tsc
 
 COPY package.json package-lock.json ./
 RUN npm install

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=$TARGETPLATFORM node:16
+FROM node:16
 RUN apt-get update
 RUN apt-get install qemu qemu-user-static binfmt-support debootstrap -y
 WORKDIR /home/node/airbyte

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:16-alpine
+FROM node:16-buster
 
 WORKDIR /home/node/airbyte
 RUN npm install --location=global npm@7 tsc

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=$BUILDPLATFORM node:16
+FROM node:16
 WORKDIR /home/node/airbyte
 RUN npm install --location=global npm@7 tsc
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:16
+FROM --platform=$BUILDPLATFORM node:16
 WORKDIR /home/node/airbyte
 RUN npm install --location=global npm@7 tsc
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,4 @@
-FROM node:16-buster
-
+FROM node:16
 WORKDIR /home/node/airbyte
 RUN npm install --location=global npm@7 tsc
 

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -25,6 +25,7 @@ steps:
       - '--bootstrap'
     id: show-target-build-platforms
   - name: gcr.io/cloud-builders/docker
+    entrypoint: "/bin/bash"
     args:
       - "-c"
       - |

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -16,8 +16,7 @@ steps:
   args:
     - "-c"
     - |
-      docker pull gcr.io/${PROJECT_ID}/linear-airbyte-source:latest
-      docker buildx build --platform=$_DOCKER_BUILDX_PLATFORMS -t gcr.io/${PROJECT_ID}/linear-airbyte-source:$BUILD_ID -t gcr.io/${PROJECT_ID}/linear-airbyte-source:latest --cache-from gcr.io/${PROJECT_ID}/linear-airbyte-source:latest --build-arg BUILDKIT_INLINE_CACHE=1 -f Dockerfile .
+      docker buildx build --platform=$_DOCKER_BUILDX_PLATFORMS -t gcr.io/${PROJECT_ID}/linear-airbyte-source:$BUILD_ID -t gcr.io/${PROJECT_ID}/linear-airbyte-source:latest -f Dockerfile .
       [[ "$BRANCH_NAME" == "main" ]] && docker push gcr.io/${PROJECT_ID}/linear-airbyte-source:$BUILD_ID || true
       docker push gcr.io/${PROJECT_ID}/linear-airbyte-source:latest
   id: build-multi-architecture-container-image

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -1,30 +1,17 @@
 steps:
-  - name: gcr.io/cloud-builders/docker
-    args:
-      - run
-      - '--privileged'
-      - 'linuxkit/binfmt:v0.7'
-    id: initialize-qemu
-  - name: gcr.io/cloud-builders/docker
-    args:
-      - buildx
-      - create
-      - '--name'
-      - mybuilder
-    id: create-builder
-  - name: gcr.io/cloud-builders/docker
-    args:
-      - buildx
-      - use
-      - mybuilder
-    id: select-builder
-  - name: gcr.io/cloud-builders/docker
-    args:
-      - buildx
-      - inspect
-      - '--bootstrap'
-    id: show-target-build-platforms
-  - name: gcr.io/cloud-builders/docker
+- name: 'gcr.io/cloud-builders/docker:20.10.3'
+      args: ['run', '--privileged', 'linuxkit/binfmt:v0.7']
+      id: 'initialize-qemu'
+    - name: 'gcr.io/cloud-builders/docker:20.10.3'
+      args: ['buildx', 'create', '--name', 'mybuilder']
+      id: 'create-builder'
+    - name: 'gcr.io/cloud-builders/docker:20.10.3'
+      args: ['buildx', 'use', 'mybuilder']
+      id: 'select-builder'
+    - name: 'gcr.io/cloud-builders/docker:20.10.3'
+      args: ['buildx', 'inspect', '--bootstrap']
+      id: 'show-target-build-platforms'
+    - name: 'gcr.io/cloud-builders/docker:20.10.3'
     entrypoint: "/bin/bash"
     args:
       - "-c"
@@ -32,7 +19,7 @@ steps:
         docker pull gcr.io/${PROJECT_ID}/linear-airbyte-source:latest
         docker buildx build --platform=$_DOCKER_BUILDX_PLATFORMS -t gcr.io/${PROJECT_ID}/linear-airbyte-source:$BUILD_ID -t gcr.io/${PROJECT_ID}/linear-airbyte-source:latest --cache-from gcr.io/${PROJECT_ID}/linear-airbyte-source:latest --build-arg BUILDKIT_INLINE_CACHE=1 -f Dockerfile .
         [[ "$BRANCH_NAME" == "main" ]] && docker push gcr.io/${PROJECT_ID}/linear-airbyte-source:$BUILD_ID || true
-        [[ "$BRANCH_NAME" == "main" ]] && docker push gcr.io/${PROJECT_ID}/linear-airbyte-source:latest || true
+        docker push gcr.io/${PROJECT_ID}/linear-airbyte-source:latest
     id: build-multi-architecture-container-image
 options:
   env:

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -23,3 +23,4 @@ options:
     - DOCKER_CLI_EXPERIMENTAL=enabled
 substitutions:
   _DOCKER_BUILDX_PLATFORMS: 'linux/amd64,linux/arm64'
+  

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -16,8 +16,7 @@ steps:
   args:
     - "-c"
     - |
-      docker buildx build --platform=$_DOCKER_BUILDX_PLATFORMS -t gcr.io/${PROJECT_ID}/linear-airbyte-source:$BUILD_ID -t gcr.io/${PROJECT_ID}/linear-airbyte-source:latest --push -f Dockerfile .
-      [[ "$BRANCH_NAME" == "main" ]] && docker push gcr.io/${PROJECT_ID}/linear-airbyte-source:$BUILD_ID || true
+      [[ "$BRANCH_NAME" == "main" ]] && docker buildx build --platform=$_DOCKER_BUILDX_PLATFORMS -t gcr.io/${PROJECT_ID}/linear-airbyte-source:$BUILD_ID -t gcr.io/${PROJECT_ID}/linear-airbyte-source:latest --push -f Dockerfile . || docker buildx build --platform=$_DOCKER_BUILDX_PLATFORMS -t gcr.io/${PROJECT_ID}/linear-airbyte-source:$BUILD_ID -t gcr.io/${PROJECT_ID}/linear-airbyte-source:latest -f Dockerfile .
   id: build-multi-architecture-container-image
 options:
   env:

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -1,10 +1,40 @@
 steps:
-  - name: "gcr.io/cloud-builders/docker"
-    entrypoint: "/bin/bash"
+  - name: gcr.io/cloud-builders/docker
+    args:
+      - run
+      - '--privileged'
+      - 'linuxkit/binfmt:v0.7'
+    id: initialize-qemu
+  - name: gcr.io/cloud-builders/docker
+    args:
+      - buildx
+      - create
+      - '--name'
+      - mybuilder
+    id: create-builder
+  - name: gcr.io/cloud-builders/docker
+    args:
+      - buildx
+      - use
+      - mybuilder
+    id: select-builder
+  - name: gcr.io/cloud-builders/docker
+    args:
+      - buildx
+      - inspect
+      - '--bootstrap'
+    id: show-target-build-platforms
+  - name: gcr.io/cloud-builders/docker
     args:
       - "-c"
       - |
         docker pull gcr.io/${PROJECT_ID}/linear-airbyte-source:latest
-        docker build -t gcr.io/${PROJECT_ID}/linear-airbyte-source:$BUILD_ID -t gcr.io/${PROJECT_ID}/linear-airbyte-source:latest --cache-from gcr.io/${PROJECT_ID}/linear-airbyte-source:latest --build-arg BUILDKIT_INLINE_CACHE=1 -f Dockerfile .
+        docker buildx build --platform=$_DOCKER_BUILDX_PLATFORMS -t gcr.io/${PROJECT_ID}/linear-airbyte-source:$BUILD_ID -t gcr.io/${PROJECT_ID}/linear-airbyte-source:latest --cache-from gcr.io/${PROJECT_ID}/linear-airbyte-source:latest --build-arg BUILDKIT_INLINE_CACHE=1 -f Dockerfile .
         [[ "$BRANCH_NAME" == "main" ]] && docker push gcr.io/${PROJECT_ID}/linear-airbyte-source:$BUILD_ID || true
         [[ "$BRANCH_NAME" == "main" ]] && docker push gcr.io/${PROJECT_ID}/linear-airbyte-source:latest || true
+    id: build-multi-architecture-container-image
+options:
+  env:
+    - DOCKER_CLI_EXPERIMENTAL=enabled
+substitutions:
+  _DOCKER_BUILDX_PLATFORMS: 'linux/amd64,linux/arm64'

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -1,6 +1,6 @@
 steps:
 - name: 'gcr.io/cloud-builders/docker:20.10.3'
-  args: ['run', '--privileged', 'linuxkit/binfmt:v0.7']
+  args: ['run', '--privileged', 'multiarch/qemu-user-static:register']
   id: 'initialize-qemu'
 - name: 'gcr.io/cloud-builders/docker:20.10.3'
   args: ['buildx', 'create', '--name', 'mybuilder']

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -1,6 +1,6 @@
 steps:
 - name: 'gcr.io/cloud-builders/docker:20.10.3'
-  args: ['run', '--privileged', 'multiarch/qemu-user-static:register']
+  args: ['run', '--privileged', 'linuxkit/binfmt:v0.7']
   id: 'initialize-qemu'
 - name: 'gcr.io/cloud-builders/docker:20.10.3'
   args: ['buildx', 'create', '--name', 'mybuilder']
@@ -16,9 +16,8 @@ steps:
   args:
     - "-c"
     - |
-      docker buildx build --platform=$_DOCKER_BUILDX_PLATFORMS -t gcr.io/${PROJECT_ID}/linear-airbyte-source:$BUILD_ID -t gcr.io/${PROJECT_ID}/linear-airbyte-source:latest --load -f Dockerfile .
+      docker buildx build --platform=$_DOCKER_BUILDX_PLATFORMS -t gcr.io/${PROJECT_ID}/linear-airbyte-source:$BUILD_ID -t gcr.io/${PROJECT_ID}/linear-airbyte-source:latest --push -f Dockerfile .
       [[ "$BRANCH_NAME" == "main" ]] && docker push gcr.io/${PROJECT_ID}/linear-airbyte-source:$BUILD_ID || true
-      docker push gcr.io/${PROJECT_ID}/linear-airbyte-source:latest
   id: build-multi-architecture-container-image
 options:
   env:

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -1,26 +1,26 @@
 steps:
 - name: 'gcr.io/cloud-builders/docker:20.10.3'
-      args: ['run', '--privileged', 'linuxkit/binfmt:v0.7']
-      id: 'initialize-qemu'
-    - name: 'gcr.io/cloud-builders/docker:20.10.3'
-      args: ['buildx', 'create', '--name', 'mybuilder']
-      id: 'create-builder'
-    - name: 'gcr.io/cloud-builders/docker:20.10.3'
-      args: ['buildx', 'use', 'mybuilder']
-      id: 'select-builder'
-    - name: 'gcr.io/cloud-builders/docker:20.10.3'
-      args: ['buildx', 'inspect', '--bootstrap']
-      id: 'show-target-build-platforms'
-    - name: 'gcr.io/cloud-builders/docker:20.10.3'
-    entrypoint: "/bin/bash"
-    args:
-      - "-c"
-      - |
-        docker pull gcr.io/${PROJECT_ID}/linear-airbyte-source:latest
-        docker buildx build --platform=$_DOCKER_BUILDX_PLATFORMS -t gcr.io/${PROJECT_ID}/linear-airbyte-source:$BUILD_ID -t gcr.io/${PROJECT_ID}/linear-airbyte-source:latest --cache-from gcr.io/${PROJECT_ID}/linear-airbyte-source:latest --build-arg BUILDKIT_INLINE_CACHE=1 -f Dockerfile .
-        [[ "$BRANCH_NAME" == "main" ]] && docker push gcr.io/${PROJECT_ID}/linear-airbyte-source:$BUILD_ID || true
-        docker push gcr.io/${PROJECT_ID}/linear-airbyte-source:latest
-    id: build-multi-architecture-container-image
+  args: ['run', '--privileged', 'linuxkit/binfmt:v0.7']
+  id: 'initialize-qemu'
+- name: 'gcr.io/cloud-builders/docker:20.10.3'
+  args: ['buildx', 'create', '--name', 'mybuilder']
+  id: 'create-builder'
+- name: 'gcr.io/cloud-builders/docker:20.10.3'
+  args: ['buildx', 'use', 'mybuilder']
+  id: 'select-builder'
+- name: 'gcr.io/cloud-builders/docker:20.10.3'
+  args: ['buildx', 'inspect', '--bootstrap']
+  id: 'show-target-build-platforms'
+- name: 'gcr.io/cloud-builders/docker:20.10.3'
+  entrypoint: "/bin/bash"
+  args:
+    - "-c"
+    - |
+      docker pull gcr.io/${PROJECT_ID}/linear-airbyte-source:latest
+      docker buildx build --platform=$_DOCKER_BUILDX_PLATFORMS -t gcr.io/${PROJECT_ID}/linear-airbyte-source:$BUILD_ID -t gcr.io/${PROJECT_ID}/linear-airbyte-source:latest --cache-from gcr.io/${PROJECT_ID}/linear-airbyte-source:latest --build-arg BUILDKIT_INLINE_CACHE=1 -f Dockerfile .
+      [[ "$BRANCH_NAME" == "main" ]] && docker push gcr.io/${PROJECT_ID}/linear-airbyte-source:$BUILD_ID || true
+      docker push gcr.io/${PROJECT_ID}/linear-airbyte-source:latest
+  id: build-multi-architecture-container-image
 options:
   env:
     - DOCKER_CLI_EXPERIMENTAL=enabled

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -16,7 +16,7 @@ steps:
   args:
     - "-c"
     - |
-      docker buildx build --platform=$_DOCKER_BUILDX_PLATFORMS -t gcr.io/${PROJECT_ID}/linear-airbyte-source:$BUILD_ID -t gcr.io/${PROJECT_ID}/linear-airbyte-source:latest -f Dockerfile .
+      docker buildx build --platform=$_DOCKER_BUILDX_PLATFORMS -t gcr.io/${PROJECT_ID}/linear-airbyte-source:$BUILD_ID -t gcr.io/${PROJECT_ID}/linear-airbyte-source:latest --load -f Dockerfile .
       [[ "$BRANCH_NAME" == "main" ]] && docker push gcr.io/${PROJECT_ID}/linear-airbyte-source:$BUILD_ID || true
       docker push gcr.io/${PROJECT_ID}/linear-airbyte-source:latest
   id: build-multi-architecture-container-image


### PR DESCRIPTION
build connector image for multiple platforms.

most folks will try airbyte locally and prob run it on new macs. we needed to push images for both platforms