### PR TITLE
chore: fixed comment schema for bodydata

### DIFF
--- a/resources/schemas/comment.json
+++ b/resources/schemas/comment.json
@@ -32,7 +32,7 @@
       "type": [ "null", "object" ]
     },
     "bodyData": {
-      "type": [ "null", "string", "object" ]
+      "type": [ "null", "string" ]
     },
     "reactionData": {
       "type": "array",


### PR DESCRIPTION
bodyData can only be string or null. having object would make airbyte create a wrong schema in destination.