### PR TITLE
chore: fix body data type

### DIFF
--- a/src/client/types.ts
+++ b/src/client/types.ts
@@ -326,7 +326,7 @@ export interface Comment {
   sourceMetadata?: null | {
     [k: string]: unknown;
   };
-  bodyData?: unknown;
+  bodyData?: string;
   reactionData?: {
     [k: string]: unknown;
   }[];


### PR DESCRIPTION
another place where it has to be string, otherwise this field is created as json in big query. no idea, why it is not using the actual schema in that case.