### PR TITLE
fix: update `Comment`, `Document` and `Initiative` schemas

### DIFF
--- a/resources/schemas/comment.json
+++ b/resources/schemas/comment.json
@@ -17,7 +17,7 @@
       "type": ["null", "string"]
     },
     "issueId": {
-      "type": "string"
+      "type": ["null", "string"]
     },
     "resolvingCommentId": {
       "type": ["null", "string"]

--- a/resources/schemas/document.json
+++ b/resources/schemas/document.json
@@ -29,7 +29,7 @@
       "type": "string"
     },
     "projectId": {
-      "type": "string"
+      "type": ["null", "string"]
     },
     "slugId": {
       "type": "string"

--- a/resources/schemas/initiative.json
+++ b/resources/schemas/initiative.json
@@ -29,7 +29,7 @@
       "type": "string"
     },
     "ownerId": {
-      "type": "string"
+      "type": ["null", "string"]
     },
     "status": {
       "type": "string"

--- a/src/client/types.ts
+++ b/src/client/types.ts
@@ -361,7 +361,7 @@ export interface Comment {
   resolvedAt?: null | string;
   issueId?: string;
   parentId?: null | string;
-  userId?: string;
+  userId?: null | string;
   resolvingUserId?: null | string;
   resolvingCommentId?: null | string;
   editedAt?: string;
@@ -431,7 +431,7 @@ export interface Document {
   color?: string;
   creatorId?: string;
   updatedById?: string;
-  projectId?: string;
+  projectId?: null | string;
   slugId?: string;
 }
 


### PR DESCRIPTION
I noticed the following entities failing the acceptance test suite when running locally.
- `issueId` on `comment` can be null (inline comments on docs)
- `ownerId` on `initiative` can be null (unassigned initiative)
- `projectId` on `document` can be null (document on an initiative)